### PR TITLE
[Step09] 동시성 고려하여 쿼리 보완!

### DIFF
--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderMapper.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderMapper.java
@@ -37,9 +37,9 @@ public interface OrderMapper {
     int insertOrderItem(OrderItem item);
 
     /**
-     * 주문상품 삭제
-     * @param orderId
+     * 주문상품 상태 변경
+     * @param item
      * @return
      */
-    int deleteItemsByOrderId(@Param("orderId") Long orderId);
+    int updateOrderItem(OrderItem item);
 }

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderRepositoryMyBatis.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderRepositoryMyBatis.java
@@ -1,11 +1,9 @@
 package com.jojo.ecommerce.adapter.out.persistence;
 
-import com.jojo.ecommerce.application.exception.AlreadyCompletedOrder;
 import com.jojo.ecommerce.application.exception.OrderNotFoundException;
 import com.jojo.ecommerce.application.port.out.OrderRepositoryPort;
 import com.jojo.ecommerce.domain.model.Order;
 import com.jojo.ecommerce.domain.model.OrderItem;
-import com.jojo.ecommerce.domain.model.STATUS_TYPE;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
@@ -48,7 +46,6 @@ public class OrderRepositoryMyBatis implements OrderRepositoryPort {
     public Order findByOrderId(Long orderId) {
         Order order = mapper.selectOrderById(orderId);
         if (order == null) throw new OrderNotFoundException(orderId);
-        if(order.getPaymentStatus().equals(STATUS_TYPE.PAYMENT_COMPLETED)) throw new AlreadyCompletedOrder();
         return order;
     }
 

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderRepositoryMyBatis.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderRepositoryMyBatis.java
@@ -1,16 +1,16 @@
 package com.jojo.ecommerce.adapter.out.persistence;
 
+import com.jojo.ecommerce.application.exception.AlreadyCompletedOrder;
 import com.jojo.ecommerce.application.exception.OrderNotFoundException;
 import com.jojo.ecommerce.application.port.out.OrderRepositoryPort;
 import com.jojo.ecommerce.domain.model.Order;
 import com.jojo.ecommerce.domain.model.OrderItem;
+import com.jojo.ecommerce.domain.model.STATUS_TYPE;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Primary
 @Repository
@@ -48,6 +48,7 @@ public class OrderRepositoryMyBatis implements OrderRepositoryPort {
     public Order findByOrderId(Long orderId) {
         Order order = mapper.selectOrderById(orderId);
         if (order == null) throw new OrderNotFoundException(orderId);
+        if(order.getPaymentStatus().equals(STATUS_TYPE.PAYMENT_COMPLETED)) throw new AlreadyCompletedOrder();
         return order;
     }
 

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderRepositoryMyBatis.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/OrderRepositoryMyBatis.java
@@ -33,15 +33,14 @@ public class OrderRepositoryMyBatis implements OrderRepositoryPort {
     @Override
     @Transactional
     public Order updateOrder(Order order) {
-        int cnt = mapper.updateOrder(order);
+            int cnt = mapper.updateOrder(order);
         if (cnt == 0) throw new OrderNotFoundException(order.getOrderId());
 
-        // 기존 items 전부 삭제 후, 재삽입
-        mapper.deleteItemsByOrderId(order.getOrderId());
         for (OrderItem item : order.getOrderItems()) {
             item.setOrderId(order.getOrderId());
-            mapper.insertOrderItem(item);
+            mapper.updateOrderItem(item);
         }
+
         return order;
     }
 

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointMapper.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointMapper.java
@@ -25,4 +25,9 @@ public interface PointMapper {
      * @return
      */
     int updatePoint(Point point);
+
+    /**
+     *  중복 포인트 충전내역 확인(중복확인)
+     */
+    int countPointByUserIdAndRequestId(Point point);
 }

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointMapper.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointMapper.java
@@ -27,7 +27,14 @@ public interface PointMapper {
     int updatePoint(Point point);
 
     /**
-     *  중복 포인트 충전내역 확인(중복확인)
+     * 포인트 요청내역 저장
+     * @param point
      */
-    int countPointByUserIdAndRequestId(Point point);
+    void insertPointCharge(Point point);
+
+    /**
+     * 포인트 충전
+     * @param point
+     */
+    void upsertAndAddPoint(Point point);
 }

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMap.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMap.java
@@ -29,13 +29,15 @@ public class PointRepositoryMap implements PointRepositoryPort {
     }
 
     @Override
-    public void savePoint(Point point) {
-        repository.put(point.getUserId(),point);
+    public void saveOrUpdatePoint(Point point) {
+       if(repository.containsKey(point.getUserId())){
+           repository.get(point.getUserId());
+       }
+        repository.put(point.getUserId(), point);
+
     }
 
     @Override
-    public int findPointByUserIdAndRequestId(Long userId, String requestId) {
-        return 0;
+    public void savePointCharge(Long userId,String requestId, int amount) {
     }
-
 }

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMap.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMap.java
@@ -28,4 +28,14 @@ public class PointRepositoryMap implements PointRepositoryPort {
        return repository.get(userId);
     }
 
+    @Override
+    public void savePoint(Point point) {
+        repository.put(point.getUserId(),point);
+    }
+
+    @Override
+    public int findPointByUserIdAndRequestId(Long userId, String requestId) {
+        return 0;
+    }
+
 }

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMyBatis.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMyBatis.java
@@ -36,15 +36,15 @@ public class PointRepositoryMyBatis implements PointRepositoryPort {
     }
 
     @Override
-    public void savePoint(Point point){
-        pointMapper.insertPoint(point);
+    public void saveOrUpdatePoint(Point point) {
+        pointMapper.upsertAndAddPoint(point);
     }
 
     @Override
-    public int findPointByUserIdAndRequestId(Long userId,String requestId) {
-        Point point = new Point();
-        point.setUserId(userId);
+    public void savePointCharge(Long userId,String requestId,int amount){
+        Point point = new Point(userId,amount);
         point.setRequestId(requestId);
-        return pointMapper.countPointByUserIdAndRequestId(point);
+
+        pointMapper.insertPointCharge(point);
     }
 }

--- a/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMyBatis.java
+++ b/src/main/java/com/jojo/ecommerce/adapter/out/persistence/PointRepositoryMyBatis.java
@@ -32,11 +32,19 @@ public class PointRepositoryMyBatis implements PointRepositoryPort {
 
     @Override
     public Point findPointByUserId(Long userId) {
-        Point point = pointMapper.selectPointByUserId(userId);
-        if (ObjectUtils.isEmpty(point)) {
-            return new Point(userId, 0);
-        }
+        return pointMapper.selectPointByUserId(userId);
+    }
 
-        return point;
+    @Override
+    public void savePoint(Point point){
+        pointMapper.insertPoint(point);
+    }
+
+    @Override
+    public int findPointByUserIdAndRequestId(Long userId,String requestId) {
+        Point point = new Point();
+        point.setUserId(userId);
+        point.setRequestId(requestId);
+        return pointMapper.countPointByUserIdAndRequestId(point);
     }
 }

--- a/src/main/java/com/jojo/ecommerce/application/dto/CreateOrderRequest.java
+++ b/src/main/java/com/jojo/ecommerce/application/dto/CreateOrderRequest.java
@@ -1,31 +1,16 @@
 package com.jojo.ecommerce.application.dto;
 
-import lombok.Getter;
 
 import java.util.List;
 
 /**
  * 사용자 요청 객체
  */
-public class CreateOrderRequest {
-    @Getter
-    private Long userId;
-    @Getter
-    private Long couponId;
-    @Getter
-    private int totalQuantity;
-    @Getter
-    private int totalPrice;
-    @Getter
-    private List<ProductDto> productDtoList;
-
-    public CreateOrderRequest(Long userId, Long couponId, int totalQuantity, int totalPrice, List<ProductDto> productDtoList) {
-        this.userId = userId;
-        this.couponId = couponId;
-        this.totalQuantity = totalQuantity;
-        this.totalPrice = totalPrice;
-        this.productDtoList = productDtoList;
-    }
-
-}
+public record CreateOrderRequest (
+     Long userId,
+     Long couponId,
+     int totalQuantity,
+     int totalPrice,
+     List<ProductDto> productDtoList
+){ }
 

--- a/src/main/java/com/jojo/ecommerce/application/dto/CreatePaymentRequest.java
+++ b/src/main/java/com/jojo/ecommerce/application/dto/CreatePaymentRequest.java
@@ -1,31 +1,18 @@
 package com.jojo.ecommerce.application.dto;
 
-import lombok.Getter;
-import lombok.Setter;
 
 import java.util.List;
 
 /**
  * 사용자 요청 객체
  */
-@Setter
-@Getter
-public class CreatePaymentRequest {
-   private Long userId;
-   private Long couponId;
-   private Long orderId;
-   private List<ProductDto> productDtoList;
-   private String paymentMethod;
-   private int paymentPrice;
 
-   public CreatePaymentRequest(Long userId, Long couponId,Long orderId, List<ProductDto> productDtoList, String paymentMethod, int paymentPrice) {
-      this.userId = userId;
-      this.couponId = couponId;
-      this.orderId = orderId;
-      this.productDtoList = productDtoList;
-      this.paymentMethod = paymentMethod;
-      this.paymentPrice = paymentPrice;
-   }
-
-}
+public record CreatePaymentRequest(
+    Long userId,
+    Long couponId,
+    Long orderId,
+    List<ProductDto> productDtoList,
+    String paymentMethod,
+    int paymentPrice
+){ }
 

--- a/src/main/java/com/jojo/ecommerce/application/dto/CreatePointChargeRequest.java
+++ b/src/main/java/com/jojo/ecommerce/application/dto/CreatePointChargeRequest.java
@@ -1,0 +1,10 @@
+package com.jojo.ecommerce.application.dto;
+
+import com.jojo.ecommerce.domain.model.Point;
+
+public record CreatePointChargeRequest(
+        Point point,
+        String RequestId
+
+) {
+}

--- a/src/main/java/com/jojo/ecommerce/application/exception/AlreadyCompletedOrder.java
+++ b/src/main/java/com/jojo/ecommerce/application/exception/AlreadyCompletedOrder.java
@@ -1,0 +1,7 @@
+package com.jojo.ecommerce.application.exception;
+
+public class AlreadyCompletedOrder extends RuntimeException {
+    public AlreadyCompletedOrder() {
+        super("이미 완료된 주문입니다");
+    }
+}

--- a/src/main/java/com/jojo/ecommerce/application/port/in/PointUseCase.java
+++ b/src/main/java/com/jojo/ecommerce/application/port/in/PointUseCase.java
@@ -1,9 +1,10 @@
 package com.jojo.ecommerce.application.port.in;
 
+import com.jojo.ecommerce.application.dto.CreatePointChargeRequest;
 import com.jojo.ecommerce.domain.model.Point;
 
 public interface PointUseCase {
     // 포인트 충전
-    Point chargePoint(Point point);
+    Point chargePoint(CreatePointChargeRequest point);
 
 }

--- a/src/main/java/com/jojo/ecommerce/application/port/out/PointRepositoryPort.java
+++ b/src/main/java/com/jojo/ecommerce/application/port/out/PointRepositoryPort.java
@@ -9,4 +9,10 @@ public interface PointRepositoryPort {
     // 유저 포인트 조회
     Point findPointByUserId(Long userId);
 
+    // 유저 포인트 조회 중복확인
+    int findPointByUserIdAndRequestId(Long userId,String requestId);
+
+    // 유저 포인트 저장
+    void savePoint(Point point);
+
 }

--- a/src/main/java/com/jojo/ecommerce/application/port/out/PointRepositoryPort.java
+++ b/src/main/java/com/jojo/ecommerce/application/port/out/PointRepositoryPort.java
@@ -9,10 +9,10 @@ public interface PointRepositoryPort {
     // 유저 포인트 조회
     Point findPointByUserId(Long userId);
 
-    // 유저 포인트 조회 중복확인
-    int findPointByUserIdAndRequestId(Long userId,String requestId);
+    // 유저 포인트 요청 저장(중복 확인용)
+    void savePointCharge(Long userId,String requestId,int amount);
 
-    // 유저 포인트 저장
-    void savePoint(Point point);
+    // 포인트 충전
+    void saveOrUpdatePoint(Point point);
 
 }

--- a/src/main/java/com/jojo/ecommerce/application/service/PaymentService.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/PaymentService.java
@@ -22,7 +22,7 @@ public class PaymentService implements PaymentUseCase {
     @Override
     @Transactional
     public Payment pay(CreatePaymentRequest createPaymentRequest) {
-        Long orderId = createPaymentRequest.getOrderId();
+        Long orderId = createPaymentRequest.orderId();
 
         // 주문정보 가져오기
         Order order = orderRepo.findByOrderId(orderId);
@@ -31,8 +31,8 @@ public class PaymentService implements PaymentUseCase {
         int amount = order.calculateTotalPrice();
 
         // 쿠폰 있을경우
-        if (createPaymentRequest.getCouponId() != null) {
-            UserCoupon userCoupon = userCouponRepo.findByUserCouponId(createPaymentRequest.getUserId(), createPaymentRequest.getCouponId());
+        if (createPaymentRequest.couponId() != null) {
+            UserCoupon userCoupon = userCouponRepo.findByUserCouponId(createPaymentRequest.userId(), createPaymentRequest.couponId());
             Coupon coupon = couponRepo.findByCouponId(userCoupon.getCouponId());
 
             // 할인율 적용하여 금액 계산
@@ -45,7 +45,7 @@ public class PaymentService implements PaymentUseCase {
         }
 
         // 유저 포인트 차감
-        Point userPoint = pointRepo.findPointByUserId(createPaymentRequest.getUserId());
+        Point userPoint = pointRepo.findPointByUserId(createPaymentRequest.userId());
         Point deductedPoint = userPoint.minusPoint(amount);
         pointRepo.updatePoint(deductedPoint);
 
@@ -57,7 +57,7 @@ public class PaymentService implements PaymentUseCase {
             productRepo.updateProduct(product);
         }
 
-        Payment payment = new Payment(orderId, createPaymentRequest.getUserId(), createPaymentRequest.getCouponId(), createPaymentRequest.getPaymentMethod(), amount);
+        Payment payment = new Payment(orderId, createPaymentRequest.userId(), createPaymentRequest.couponId(), createPaymentRequest.paymentMethod(), amount);
 
         // 결제 완료처리
         payment.paymentCompleted();

--- a/src/main/java/com/jojo/ecommerce/application/service/PaymentService.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/PaymentService.java
@@ -1,6 +1,7 @@
 package com.jojo.ecommerce.application.service;
 
 import com.jojo.ecommerce.application.dto.CreatePaymentRequest;
+import com.jojo.ecommerce.application.exception.AlreadyCompletedOrder;
 import com.jojo.ecommerce.application.port.in.PaymentUseCase;
 import com.jojo.ecommerce.application.port.out.*;
 import com.jojo.ecommerce.domain.model.*;
@@ -26,6 +27,8 @@ public class PaymentService implements PaymentUseCase {
 
         // 주문정보 가져오기
         Order order = orderRepo.findByOrderId(orderId);
+        if(order.getPaymentStatus().equals(STATUS_TYPE.PAYMENT_COMPLETED))
+            throw new AlreadyCompletedOrder();
 
         // 결제금액 계산
         int amount = order.calculateTotalPrice();

--- a/src/main/java/com/jojo/ecommerce/application/service/PlaceOrderService.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/PlaceOrderService.java
@@ -17,11 +17,11 @@ public class PlaceOrderService implements OrderUseCase {
     @Override
     public Order placeOrder(CreateOrderRequest createOrderRequest){
         // 주문 생성
-        Order order = new Order(createOrderRequest.getUserId());
+        Order order = new Order(createOrderRequest.userId());
         Order saved = orderRepositoryPort.saveOrder(order);
 
         // 상품 주문정보 돌면서 주문 아이템 생성
-        for(ProductDto productDto : createOrderRequest.getProductDtoList()){
+        for(ProductDto productDto : createOrderRequest.productDtoList()){
             order.addOrderItem(new OrderItem(order.getOrderId(),productDto.getProductId(), productDto.getQauntity(),productDto.getProductPrice()));
         }
 

--- a/src/main/java/com/jojo/ecommerce/application/service/PointService.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/PointService.java
@@ -1,22 +1,43 @@
 package com.jojo.ecommerce.application.service;
 
-import com.jojo.ecommerce.application.port.in.PointUseCase;
-import com.jojo.ecommerce.application.port.out.PointRepositoryPort;
+import com.jojo.ecommerce.adapter.out.persistence.PointMapper;
+import com.jojo.ecommerce.application.dto.CreatePointChargeRequest;
 import com.jojo.ecommerce.domain.model.Point;
+import com.sun.jdi.request.DuplicateRequestException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class PointService implements PointUseCase {
-    private final PointRepositoryPort pointRepositoryPort;
+public class PointService {
+    private final PointMapper mapper;
 
+    @Transactional
+    public Point chargePoint(CreatePointChargeRequest createPointChargeRequest) {
+        Point point = createPointChargeRequest.point();
+        point.setRequestId(createPointChargeRequest.RequestId());
+        int already = mapper.countPointByUserIdAndRequestId(point);
 
-    @Override
-    public Point chargePoint(Point point) {
-        Point savedPoint = pointRepositoryPort.findPointByUserId(point.getUserId());
-        Point chargedPoint = savedPoint.addPoint(point.getPoint());
-        return pointRepositoryPort.updatePoint(chargedPoint);
+        // 1) 중복 충전 확인
+        if (already > 0) {
+            throw new DuplicateRequestException("이미 처리된 요청입니다: ");
+        }
+
+        // 2) 기존 포인트 조회
+        Long userId = point.getUserId();
+        Point saved = mapper.selectPointByUserId(userId);
+
+        if (saved == null) {
+            // 신규 사용자: INSERT
+            mapper.insertPoint(point);
+            return point;
+
+        } else {
+            // 기존 사용자: UPDATE
+            Point addedPoint = saved.addPoint(point.getPoint());
+            mapper.updatePoint(addedPoint);
+            return saved;
+        }
     }
-
 }

--- a/src/main/java/com/jojo/ecommerce/application/service/PointService.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/PointService.java
@@ -2,42 +2,35 @@ package com.jojo.ecommerce.application.service;
 
 import com.jojo.ecommerce.adapter.out.persistence.PointMapper;
 import com.jojo.ecommerce.application.dto.CreatePointChargeRequest;
+import com.jojo.ecommerce.application.port.out.PointRepositoryPort;
 import com.jojo.ecommerce.domain.model.Point;
 import com.sun.jdi.request.DuplicateRequestException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class PointService {
-    private final PointMapper mapper;
+    private final PointRepositoryPort pointRepo;
 
     @Transactional
-    public Point chargePoint(CreatePointChargeRequest createPointChargeRequest) {
-        Point point = createPointChargeRequest.point();
-        point.setRequestId(createPointChargeRequest.RequestId());
-        int already = mapper.countPointByUserIdAndRequestId(point);
+    public Point chargePoint(CreatePointChargeRequest req) {
+        Long userId = req.point().getUserId();
+        int amount = req.point().getPoint();
+        String requestId = req.RequestId();
 
-        // 1) 중복 충전 확인
-        if (already > 0) {
-            throw new DuplicateRequestException("이미 처리된 요청입니다: ");
+        try {
+            // (user_id, request_id) UNIQUE
+            // 요청내역 우선 저장
+            pointRepo.savePointCharge(userId, requestId, amount);
+        } catch (DuplicateKeyException e) {
+            throw new DuplicateRequestException("이미 처리된 요청입니다:");
         }
 
-        // 2) 기존 포인트 조회
-        Long userId = point.getUserId();
-        Point saved = mapper.selectPointByUserId(userId);
-
-        if (saved == null) {
-            // 신규 사용자: INSERT
-            mapper.insertPoint(point);
-            return point;
-
-        } else {
-            // 기존 사용자: UPDATE
-            Point addedPoint = saved.addPoint(point.getPoint());
-            mapper.updatePoint(addedPoint);
-            return saved;
-        }
+        // 원자적 증가
+        pointRepo.saveOrUpdatePoint(new Point(userId, amount));
+        return pointRepo.findPointByUserId(userId);
     }
 }

--- a/src/main/java/com/jojo/ecommerce/domain/model/Order.java
+++ b/src/main/java/com/jojo/ecommerce/domain/model/Order.java
@@ -20,6 +20,10 @@ public class Order extends Common {
 
     public void paymentCompleted() {
         this.paymentStatus = STATUS_TYPE.PAYMENT_COMPLETED;
+
+        for(OrderItem orderItem : orderItems) {
+            orderItem.setPaymentStatus(STATUS_TYPE.PAYMENT_COMPLETED);
+        }
     }
 
     public void paymentCanceled() {

--- a/src/main/java/com/jojo/ecommerce/domain/model/PaymentHistory.java
+++ b/src/main/java/com/jojo/ecommerce/domain/model/PaymentHistory.java
@@ -1,11 +1,15 @@
 package com.jojo.ecommerce.domain.model;
 
 import com.jojo.ecommerce.domain.Common;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Setter
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class PaymentHistory extends Common {
     private Long paymentHistoryId;
     private Long paymentId;

--- a/src/main/java/com/jojo/ecommerce/domain/model/Point.java
+++ b/src/main/java/com/jojo/ecommerce/domain/model/Point.java
@@ -2,16 +2,21 @@ package com.jojo.ecommerce.domain.model;
 
 import com.jojo.ecommerce.application.exception.InsufficientPointException;
 import com.jojo.ecommerce.domain.Common;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 
 @Setter
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Point extends Common {
     private Long pointId;
     private Long userId;
     private int point; // 포인트 총액
+    private String requestId;
 
     public Point(Long userId, int point) {
         this.userId = userId;

--- a/src/main/resources/mapper/ecommerce-order.xml
+++ b/src/main/resources/mapper/ecommerce-order.xml
@@ -22,19 +22,6 @@
         <collection property="orderItems" ofType="com.jojo.ecommerce.domain.model.OrderItem" resultMap="OrderItemResult"/>
     </resultMap>
 
-    <select id="selectItemsByOrderId" resultMap="OrderResult" parameterType="Long">
-        SELECT
-            order_item_id
-          , order_id
-          , product_id
-          , unit_price
-          , quantity
-          , reg_date
-          , upd_date
-        FROM order_item
-        WHERE order_id = #{orderId}
-    </select>
-
     <select id="selectOrderById" resultMap="OrderResult" parameterType="Long">
         SELECT o.order_id,
                o.user_id,
@@ -51,6 +38,7 @@
         FROM orders o
                  LEFT JOIN order_item i ON o.order_id = i.order_id
         WHERE o.order_id = #{orderId}
+        FOR UPDATE
     </select>
 
 

--- a/src/main/resources/mapper/ecommerce-order.xml
+++ b/src/main/resources/mapper/ecommerce-order.xml
@@ -2,37 +2,27 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.jojo.ecommerce.adapter.out.persistence.OrderMapper">
-
-    <resultMap id="ItemResult" type="com.jojo.ecommerce.domain.model.OrderItem">
+    <resultMap id="OrderItemResult" type="com.jojo.ecommerce.domain.model.OrderItem">
         <id column="order_item_id"    property="orderItemId"/>
         <result column="order_id"   property="orderId"/>
         <result column="product_id" property="productId"/>
-        <result column="unit_price" property="unitPrice"/>
         <result column="quantity"   property="quantity"/>
+        <result column="unit_price"      property="unitPrice"/>
         <result column="reg_date"   property="regDate"/>
         <result column="upd_date"   property="updDate"/>
-    </resultMap>
-
-    <resultMap id="OrderItemResult" type="com.jojo.ecommerce.domain.model.OrderItem">
-        <id column="item_id"    property="itemId"/>
-        <result column="order_id"   property="orderId"/>
-        <result column="product_id" property="productId"/>
-        <result column="quantity"   property="quantity"/>
-        <result column="price"      property="price"/>
-        <result column="reg_date"   property="regDate"/>
-        <result column="upd_date"   property="updDate"/>
+        <result column="payment_status" property="paymentStatus"/>
     </resultMap>
 
     <resultMap id="OrderResult" type="com.jojo.ecommerce.domain.model.Order">
         <id column="order_id"   property="orderId"/>
         <result column="user_id"    property="userId"/>
         <result column="reg_date"   property="regDate"/>
-        <result column="payment_status" property="paymentStatus" javaType="com.jojo.ecommerce.domain.model.STATUS_TYPE" typeHandler="org.apache.ibatis.type.EnumTypeHandler"/>
+        <result column="payment_status" property="paymentStatus"/>
         <result column="upd_date"   property="updDate"/>
         <collection property="orderItems" ofType="com.jojo.ecommerce.domain.model.OrderItem" resultMap="OrderItemResult"/>
     </resultMap>
 
-    <select id="selectItemsByOrderId" resultMap="ItemResult" parameterType="long">
+    <select id="selectItemsByOrderId" resultMap="OrderResult" parameterType="Long">
         SELECT
             order_item_id
           , order_id
@@ -45,17 +35,19 @@
         WHERE order_id = #{orderId}
     </select>
 
-    <select id="selectOrderById" resultMap="OrderResult" parameterType="long">
+    <select id="selectOrderById" resultMap="OrderResult" parameterType="Long">
         SELECT o.order_id,
                o.user_id,
                o.reg_date,
                o.upd_date,
+               o.payment_status,
                i.order_item_id,
                i.product_id,
                i.quantity,
                i.unit_price,
-               i.reg_date AS reg_date,
-               i.upd_date AS upd_date
+               i.payment_status,
+               o.reg_date,
+               o.upd_date
         FROM orders o
                  LEFT JOIN order_item i ON o.order_id = i.order_id
         WHERE o.order_id = #{orderId}
@@ -76,8 +68,15 @@
 
     <update id="updateOrder" parameterType="com.jojo.ecommerce.domain.model.Order">
         UPDATE orders
-        SET payment_status = #{paymentStatus},
-            upd_date = NOW()
+        SET   payment_status = #{paymentStatus}
+            , upd_date = NOW()
+        WHERE order_id = #{orderId}
+    </update>
+
+    <update id="updateOrderItem" parameterType="com.jojo.ecommerce.domain.model.OrderItem">
+        UPDATE order_item
+        SET  payment_status = #{paymentStatus}
+            , upd_date = NOW()
         WHERE order_id = #{orderId}
     </update>
 
@@ -97,11 +96,5 @@
           , NOW()
         )
     </insert>
-
-    <delete id="deleteItemsByOrderId" parameterType="long">
-        DELETE
-        FROM order_item
-        WHERE order_id = #{orderId}
-    </delete>
 
 </mapper>

--- a/src/main/resources/mapper/ecommerce-payment-history.xml
+++ b/src/main/resources/mapper/ecommerce-payment-history.xml
@@ -5,7 +5,7 @@
     <resultMap id="PaymentHistoryMap" type="com.jojo.ecommerce.domain.model.PaymentHistory">
         <id column="payment_history_id" property="paymentHistoryId"/>
         <result column="payment_id"          property="paymentId"/>
-        <result column="payment_status"      property="paymentStatus" javaType="com.jojo.ecommerce.domain.model.STATUS_TYPE" typeHandler="org.apache.ibatis.type.EnumTypeHandler"/>
+        <result column="payment_status"      property="paymentStatus"/>
         <result column="reg_date"            property="regDate"/>
         <result column="upd_date"            property="updDate"/>
     </resultMap>
@@ -22,7 +22,7 @@
         )
     </insert>
 
-    <select id="selectByPaymentId" resultMap="PaymentHistoryMap" parameterType="long">
+    <select id="selectByPaymentId" resultMap="PaymentHistoryMap" parameterType="Long">
         SELECT
             payment_history_id,
             payment_id,

--- a/src/main/resources/mapper/ecommerce-point.xml
+++ b/src/main/resources/mapper/ecommerce-point.xml
@@ -20,6 +20,7 @@
           , upd_date
         FROM point
         WHERE user_id = #{userId}
+        FOR UPDATE
     </select>
 
     <insert id="insertPoint" parameterType="com.jojo.ecommerce.domain.model.Point" useGeneratedKeys="true" keyProperty="pointId">

--- a/src/main/resources/mapper/ecommerce-point.xml
+++ b/src/main/resources/mapper/ecommerce-point.xml
@@ -21,7 +21,6 @@
           , upd_date
         FROM point
         WHERE user_id = #{userId}
-        FOR UPDATE
     </select>
 
     <insert id="insertPoint" parameterType="com.jojo.ecommerce.domain.model.Point" useGeneratedKeys="true" keyProperty="pointId">
@@ -53,5 +52,36 @@
         WHERE user_id = #{userId}
         AND request_id = #{requestId}
     </select>
+
+    <insert id="insertPointCharge" parameterType="com.jojo.ecommerce.domain.model.Point">
+        INSERT INTO point_charge (
+            user_id
+          , request_id
+          , point
+          , reg_date
+        )
+        VALUES (
+            #{userId}
+          , #{requestId}
+          , #{point}
+          , NOW()
+        )
+    </insert>
+
+    <update id="upsertAndAddPoint" parameterType="com.jojo.ecommerce.domain.model.Point">
+        INSERT INTO point (
+            user_id
+          , point
+          , reg_date
+        )
+        VALUES (
+            #{userId}
+          , #{point}
+          , NOW()
+        )
+        ON DUPLICATE KEY UPDATE
+            point = point + VALUES(point)
+          , upd_date = NOW()
+    </update>
 
 </mapper>

--- a/src/main/resources/mapper/ecommerce-point.xml
+++ b/src/main/resources/mapper/ecommerce-point.xml
@@ -7,6 +7,7 @@
         <id column="point_id"   property="pointId"/>
         <result column="user_id"    property="userId"/>
         <result column="point"      property="point"/>
+        <result column="request_id" property="requestId"/>
         <result column="reg_date"   property="regDate"/>
         <result column="upd_date"   property="updDate"/>
     </resultMap>
@@ -27,10 +28,12 @@
         INSERT INTO point (
             user_id
           , point
+          , request_id
           , reg_date
         ) VALUES (
             #{userId}
           , #{point}
+          , #{requestId}
           , NOW()
         )
     </insert>
@@ -39,8 +42,16 @@
         UPDATE point
         SET
             point = #{point}
+          , request_id = #{requestId}
           , upd_date = NOW()
         WHERE user_id = #{userId}
     </update>
+
+    <select id="countPointByUserIdAndRequestId" resultType="int" parameterType="com.jojo.ecommerce.domain.model.Point">
+        SELECT COUNT(1)
+        FROM point
+        WHERE user_id = #{userId}
+        AND request_id = #{requestId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mapper/ecommerce-product.xml
+++ b/src/main/resources/mapper/ecommerce-product.xml
@@ -24,6 +24,7 @@
           , upd_date
         FROM product
         WHERE product_id = #{productId}
+        FOR UPDATE
     </select>
 
     <select id="selectAllProducts" resultMap="ProductMap">

--- a/src/main/resources/mapper/ecommerce-user-coupon.xml
+++ b/src/main/resources/mapper/ecommerce-user-coupon.xml
@@ -23,6 +23,7 @@
         FROM user_coupon
         WHERE user_id = #{userId}
         AND coupon_id = #{couponId}
+        FOR UPDATE
     </select>
 
     <insert id="insertUserCoupon" parameterType="com.jojo.ecommerce.domain.model.UserCoupon">
@@ -54,6 +55,7 @@
         FROM user_coupon
         WHERE user_id = #{userId}
         AND coupon_id = #{couponId}
+        FOR UPDATE
     </select>
 
 </mapper>

--- a/src/test/java/com/jojo/ecommerce/OrderRepositoryTest.java
+++ b/src/test/java/com/jojo/ecommerce/OrderRepositoryTest.java
@@ -89,11 +89,11 @@ public class OrderRepositoryTest {
         CreateOrderRequest createOrderRequest = new CreateOrderRequest(1L,null,3,3000,productDtoList);
 
         // 주문 생성
-        Order order = new Order(createOrderRequest.getUserId());
+        Order order = new Order(createOrderRequest.userId());
         Order saved = repo.saveOrder(order);
 
         // 상품 주문정보 돌면서 주문 아이템 생성
-        for(ProductDto productDto : createOrderRequest.getProductDtoList()){
+        for(ProductDto productDto : createOrderRequest.productDtoList()){
             order.addOrderItem(new OrderItem(order.getOrderId(),productDto.getProductId(), productDto.getQauntity(), productDto.getProductPrice()));
         }
 

--- a/src/test/java/com/jojo/ecommerce/PaymentServiceIntegrationTest.java
+++ b/src/test/java/com/jojo/ecommerce/PaymentServiceIntegrationTest.java
@@ -5,15 +5,15 @@ import com.jojo.ecommerce.application.dto.ProductDto;
 import com.jojo.ecommerce.application.port.out.*;
 import com.jojo.ecommerce.application.service.PaymentService;
 import com.jojo.ecommerce.domain.model.*;
+import com.jojo.ecommerce.domain.model.Order;
 import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
+import static com.jojo.ecommerce.domain.model.STATUS_TYPE.PAYMENT_CANCELED;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 @SpringBootTest
 @Transactional
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class PaymentServiceIntegrationTest {
     @Autowired
     private PaymentService paymentService;
@@ -47,7 +48,7 @@ public class PaymentServiceIntegrationTest {
     private Coupon coupon;
     private List<ProductDto> productList;
 
-    @BeforeEach
+    @BeforeAll
     void setUp() {
         // 1) 상품 세팅
         apple = productRepo.save(new Product("사과", 10, 1000, 101));
@@ -111,7 +112,6 @@ public class PaymentServiceIntegrationTest {
     }
 
 
-    @Disabled
     @Test
     void cancelPayment_통합_테스트() {
         // 먼저 결제
@@ -133,11 +133,11 @@ public class PaymentServiceIntegrationTest {
         assertTrue(cancelResult);
 
         // a) 결제상태 & 주문 상태 취소 확인
-        assertEquals(STATUS_TYPE.PAYMENT_CANCELED,
+        assertEquals(PAYMENT_CANCELED,
                 paymentRepo.findByPaymentId(paymentId).getPaymentStatus());
 
-       // assertEquals(PAYMENT_CANCELED,
-      //          orderRepo.findByOrderId(order.getOrderId()).getPaymentStatus());
+       assertEquals(PAYMENT_CANCELED,
+                orderRepo.findByOrderId(order.getOrderId()).getPaymentStatus());
 
         // b) 재고 원복 확인
         assertEquals(10, productRepo.findProductById(apple.getProductId()).getStock());

--- a/src/test/java/com/jojo/ecommerce/PointServiceIntegrationTest.java
+++ b/src/test/java/com/jojo/ecommerce/PointServiceIntegrationTest.java
@@ -1,8 +1,10 @@
 package com.jojo.ecommerce;
 
+import com.jojo.ecommerce.application.dto.CreatePointChargeRequest;
 import com.jojo.ecommerce.application.port.out.PointRepositoryPort;
 import com.jojo.ecommerce.application.service.PointService;
 import com.jojo.ecommerce.domain.model.Point;
+import com.sun.jdi.request.DuplicateRequestException;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * 성공!
@@ -25,39 +28,49 @@ public class PointServiceIntegrationTest {
 
     private final Long userId = 777L;
 
-    @BeforeEach
-    void setUp() {
-        pointRepo.updatePoint(new Point(userId, 1000));
-    }
-
     @Test
     void charge_포인트_정상_충전() {
-        // given: 현재 잔액 1000
-        Point before = pointRepo.findPointByUserId(userId);
-        assertEquals(1000, before.getPoint(), "초기 포인트는 1000이어야 한다");
 
-        // when: 500원 충전
-        Point after = pointService.chargePoint(new Point(userId, 500));
+        //500 원 충전요청
+        CreatePointChargeRequest createPointChargeRequest = new CreatePointChargeRequest(new Point(userId, 500),"1234");
+        Point after = pointService.chargePoint(createPointChargeRequest);
 
-        //  모두 잔액 1500
-        assertEquals(1500, after.getPoint(), "반환된 Point 잔액이 1500이어야 한다");
-        Point persisted = pointRepo.findPointByUserId(userId);
-        assertEquals(1500, persisted.getPoint(), "저장소에 반영된 Point 잔액이 1500이어야 한다");
+        //  모두 잔액 500
+        assertEquals(500, after.getPoint(), "반환된 Point 잔액이 오백원이어야 한다");
+
+        //500 원 충전요청
+        CreatePointChargeRequest createPointChargeRequest2 = new CreatePointChargeRequest(new Point(userId, 500),"4567");
+         pointService.chargePoint(createPointChargeRequest2);
+        Point saved = pointRepo.findPointByUserId(userId);
+        assertEquals(1000, saved.getPoint(), "저장소에 반영된 Point 잔액이 1000 한다");
     }
 
     @Test
     void charge_신규사용자_포인트_충전() {
         // given: 초기화되지 않은 새 사용자 ID
         Long newUserId = 888L;
-        Point initial = pointRepo.findPointByUserId(newUserId);
-        assertEquals(0, initial.getPoint(), "신규 사용자는 초기 포인트 0이어야 한다");
+        CreatePointChargeRequest createPointChargeRequest = new CreatePointChargeRequest(new Point(newUserId, 200),"2345");
 
         // when: 200 포인트 충전
-        Point charged = pointService.chargePoint(new Point(newUserId, 200));
+        Point charged = pointService.chargePoint(createPointChargeRequest);
 
         // then
         assertEquals(200, charged.getPoint(), "신규 사용자 충전 후 잔액이 200이어야 한다");
         assertEquals(200, pointRepo.findPointByUserId(newUserId).getPoint(),
                 "저장소에도 200이 반영되어야 한다");
     }
+
+    @Test
+    void 중복해서_요청_불가() {
+        // given: 최초 충전 요청
+        CreatePointChargeRequest first = new CreatePointChargeRequest(new Point(userId, 300), "12345");
+        pointService.chargePoint(first);
+
+        // when & then: 동일 requestId로 재요청 시 예외 발생
+        CreatePointChargeRequest duplicate = new CreatePointChargeRequest(new Point(userId, 300), "12345");
+        assertThrows(DuplicateRequestException.class,
+                () -> pointService.chargePoint(duplicate),
+                "동일한 requestId로 중복 충전 들어오면 에외 발생해야 한다");
+    }
+
 }


### PR DESCRIPTION
## :pushpin: PR 제목 규칙
[STEP09] 조주아 (e-commerce)

---

## :clipboard: 핵심 체크리스트 :white_check_mark:

### STEP09 - Concurrency (2개)
- [ ] 애플리케이션 내에서 발생 가능한 **동시성 문제를 식별**했는가?
- [ ] 보고서에 DB를 활용한 **동시성 문제 해결 방안**이 포함되어 있는가?

---

### STEP10 - Finalize (1개)
- [ ] **동시성 문제를 드러낼 수 있는 통합 테스트**를 작성했는가?

---

## ✍️ 간단 회고 (3줄 이내)
- **잘한 점**: 
- 트랜잭션 = 락이라고 생각했던것 같다. 이번 기회에 두개가 별개라는것을 알게되었고, select for update가 락을 잡으면 락을 잡은 트랜잭션만 update를 칠 수 있게 해주는데 그 트랜잭션을 자바단에서 결정하는걸 알게됐다. 그리고 포인트 충전의 경우에는 단순히 select - for update 를 사용한다고 해결되는것이 아니었다. 우선 락을 잡고, 고유키로 등록된 내역이 있는지 확인 한 후 업데이트를 쳐야한다
-> 즉 [락을 잡음 -> 고유키로 등록된 내역 있는지 확인 -> 기존 유저는 포인트 업데이트 or 신규유저는 포인트 인서트 수행]  순서가 중요

- 위처럼 코드를 작성했더니 동시성 보장되지 않는것을 뒤늦게 확인했다. 인서트는 동시성 보장되지만, 업데이트를 할 때에는 안됨. 
     행이 있다면(기존유저) select for update 로 락을 잡아서 괜찮지만 행이 없으면(신규 유저) select for update는 락을 못잡음. 따라서 신규 유저일 경우 여러번 인서트를 수행하여 동시성 테스트를 통과하지 못했다.

- 1)요청id를 저장하는 새로운 테이블을 만든다. 요청id, user_id를 유니크키로 묶어 insert시 원자성 보장되게한다.
2)신규유저 insert / 기존유저 update를 업서트 쿼리 하나로 수행하여 원자적으로 수행될 수 있도록 한다.

- **어려웠던 점**: 
- **다음 시도**: DB 포트 jpa 구현체 추가하기 
- 이외에도 지난주 피드백 코드에 적용하기



## 🧾 결제 로직 동시성 문제 해결 보고서

### ✅ 문제 식별

포인트충전 / 재고차감 / 결제 로직에서 다수의 스레드가 동시에 결제 시도를 하게 되면, 동시성 문제가 발생. 

---

### 🔍 분석

#### 결제

- 주문 조회 로직에서 다수의 스레드가 동시에 주문조회를 할 경우, 동시에 재고를 차감하고, 결제하는 상황 발생
- DB 차원에서 명시적으로 주문 상태 및 재고를 조회할 때 락을 걸어서 업데이트 해야한다.

#### 포인트 충전
- 결제와 마찬가지로 조회할 때 락을 거는 방식만으로는 해결되지 않음. -> 동시에 여러 스레드가 접근할 경우, 락을 걸면 순차적으로 포인트를 충전하게 되기 때문임.
- 따라서 요청마다 고유한 id값을 주고, 해당 값으로 업데이트된 내역이 없다면 포인트 충전 진행
---

### 💡 해결 방안
#### [결제] DB에서 비관적 잠금 (SELECT FOR UPDATE)



```xml
<select id="selectOrderById" resultMap="OrderResult" parameterType="long">
    SELECT
        order_id,
        user_id,
        payment_status,
        reg_date,
        upd_date
    FROM orders
    WHERE order_id = #{orderId}
    FOR UPDATE
</select>
```
MyBatis XML 매퍼에서 `FOR UPDATE`를 활용하여 주문을 배타적으로 조회
``` java
  @Transactional
    public Payment pay(CreatePaymentRequest createPaymentRequest) {
        Long orderId = createPaymentRequest.orderId();

        // 주문정보 가져오기
        Order order = orderRepo.findByOrderId(orderId); // select for update 로 락 걸린상태
        if(order.getPaymentStatus().equals(STATUS_TYPE.PAYMENT_COMPLETED))
            throw new AlreadyCompletedOrder();

        // 결제금액 계산
        int amount = order.calculateTotalPrice();
```
한 트랜잭션 안에서 [조회 - 업데이트 쿼리] 실행하면 한번에 하나의 트랜잭션만 처리하는것이 보장된다


#### [포인트 충전] 고유한 요청ID값 이용 / 업서트 쿼리 이용
```xml
    <insert id="insertPointCharge" parameterType="com.jojo.ecommerce.domain.model.Point">
        INSERT INTO point_charge (
            user_id             
          , request_id
          , point
          , reg_date
        )
        VALUES (
            #{userId}
          , #{requestId}
          , #{point}
          , NOW()
        )
    </insert>
```
user_id, request_id 두개를 묶어 유니크 키로 지정. 따라서 인서트시 동시성 보장

```xml
    <update id="upsertAndAddPoint" parameterType="com.jojo.ecommerce.domain.model.Point">
        INSERT INTO point (
            user_id
          , point
          , reg_date
        )
        VALUES (
            #{userId}
          , #{point}
          , NOW()
        )
        ON DUPLICATE KEY UPDATE
            point = point + VALUES(point)
          , upd_date = NOW()
    </update>
```
point 테이블에서는 user_id를 유니크 키로 지정하여, 신규 유저인경우에는 인서트를, 기존 유저인 경우에는 업데이트친다.


```java
    @Transactional
    public Point chargePoint(CreatePointChargeRequest req) {
        Long userId = req.point().getUserId();
        int amount = req.point().getPoint();
        String requestId = req.RequestId();

        try {
            // (user_id, request_id) UNIQUE
            // 요청내역 우선 저장
            pointRepo.savePointCharge(userId, requestId, amount);
        } catch (DuplicateKeyException e) {
            throw new DuplicateRequestException("이미 처리된 요청입니다:");
        }

        // 원자적 증가
        // 쿼리에서 한번에 이서트/업데이트 치므로 스레드 한번만 탄다(?)
        pointRepo.saveOrUpdatePoint(new Point(userId, amount));
        return pointRepo.findPointByUserId(userId);
    }
```
1) 요청 내역 우선 저장한다.
2) 신규 유저일 경우, insert 수행, 기존 유저일 경우 update수행. 쿼리에서 한번에 해결하므로 스레드는 한번만 탄다.



