### PR TITLE
STEP15

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,87 +1,16 @@
-# 🛒 E-Commerce 조회 성능 최적화 보고서
-
-
----
-
-## 📑 목차
-
-1. [주요 조회 기능 식별](#1-주요-조회-기능-식별)
-2. [병목 원인 분석](#2-병목-원인-분석)
-3. [최적화 방안 제안](#3-최적화-방안-제안)
-    - 3.1 [쿼리 재설계](#31-쿼리-재설계)
-    - 3.2 [인덱스 설계](#32-인덱스-설계)
-    - 3.3 [기타 최적화 기법](#33-기타-최적화-기법)
-4. [검증 및 권장 사항](#4-검증-및-권장-사항)
+## :pushpin: PR 제목 규칙
+[STEP0X] 이름 - 선택 시나리오 (e-commerce/concert)
 
 ---
+### STEP 15 Application Event
+- [] 주문/예약 정보를 원 트랜잭션이 종료된 이후에 전송
+- [] 주문/예약 정보를 전달하는 부가 로직에 대한 관심사를 메인 서비스에서 분리
 
-## 1. 주요 조회 기능 식별
+### STEP 16 Transaction Diagnosis
+- [] 도메인별로 트랜잭션이 분리되었을 때 발생 가능한 문제 파악
+- [] 트랜잭션이 분리되더라도 데이터 일관성을 보장할 수 있는 분산 트랜잭션 설계
 
-| 기능(Module)            | 매퍼 메서드                                           | SQL                                             |
-|-------------------------|-------------------------------------------------------|---------------------------------------------------|
-| ** 단건 주문 조회**     | `OrderMapper.selectOrderById(orderId)`                | `SELECT … FROM orders o LEFT JOIN order_item i …` |
-| ** 결제 정보 조회**     | `PaymentMapper.selectPaymentById(paymentId)`          | `SELECT … FROM payment WHERE payment_id = #{id}`  |
-| ** 결제 이력 조회**     | `PaymentHistoryMapper.selectByPaymentId(id)`          | `SELECT * FROM payment_history WHERE payment_id = #{id}` |
-| ** 사용자 포인트 조회**   | `PointMapper.findPointByUserId(userId)`               | `SELECT point FROM point WHERE user_id = #{userId}` |
-
----
-
-## 2. 병목 원인 분석
-
-### 2.1 주문 조회 (`selectOrderById`)
-- **문제점**
-    - `orders ⇆ order_item` 조인 시 `order_item.order_id`에 인덱스 미존재 → 풀 테이블 스캔
-    - MyBatis 컬렉션 매핑 시 N+1 쿼리 발생 가능
-- **징후**
-    - 주문 항목이 많을 때 응답 지연
-    - EXPLAIN 결과 `order_item` 테이블 `ALL` 스캔
-
-### 2.2 결제 이력 조회 (`payment_history`)
-- **문제점**
-    - `payment_history.payment_id`에 인덱스 미존재 → 전체 스캔
-- **징후**
-    - 히스토리 건수가 많으면 DB CPU 사용률 급증
-
-### 2.3 만약 like 조건을 쓴다면 (`LIKE '%…%'`)
-- **문제점**
-    - 와일드카드(`%`) 양쪽 사용 시 인덱스 미스 → 전체 스캔
-- **징후**
-    - 대량 상품 검색 시 문자열 매칭 비용 급증
-
----
-
-## 3. 최적화 방안 제안
-
-### 3.1 쿼리 재설계
-
-1. **조인 분리 호출**
-   ```sql
-   -- Before
-   SELECT o.*, i.*
-     FROM orders o
-     LEFT JOIN order_item i ON o.order_id = i.order_id
-    WHERE o.order_id = :orderId;
-
-   -- After
-   -- 1) 주문 메타
-   SELECT order_id, user_id, payment_status, reg_date, upd_date
-     FROM orders
-    WHERE order_id = :orderId;
-
-   -- 2) 주문 항목
-   SELECT order_item_id, order_id, product_id, unit_price, quantity
-     FROM order_item
-    WHERE order_id = :orderId;
-### 3.2 인덱스 설계
-
-| 테이블            | 컬럼             | 제안 인덱스                                | 비고                                         |
-|-------------------|------------------|-------------------------------------------|----------------------------------------------|
-| `orders`          | `user_id`        | `idx_orders_user(user_id, order_id)`      | 사용자별 주문 목록 조회 최적화               |
-| `order_item`      | `order_id`       | `idx_item_order(order_id)`                | FK 조인 가속                                 |
-| `payment`         | `user_id`        | `idx_payment_user(user_id)`               | 사용자별 결제 내역 조회 가속                 |
-| `payment_history` | `payment_id`     | `idx_phistory_payment(payment_id)`        | 결제별 이력 빠른 조회                        |
-| `product`         | `product_code`   | `uniq_prod_code(product_code)`            | 코드 기반 직접 조회                         |
-|                   | `name`           | `FULLTEXT(name)`                          | 와일드카드 검색용 (MySQL InnoDB Fulltext)    |
-| `point`           | `user_id`        | `idx_point_user(user_id)`                 | 포인트 조회 가속                             |
-
-> **Tip:** 자주 쓰는 조합 조건에는 복합 인덱스(`(user_id, payment_status)`, `(order_id, product_id)` 등) 추가 고려  
+### **간단 회고** (3줄 이내)
+- **잘한 점**:
+- **어려운 점**:
+- **다음 시도**:

--- a/src/main/java/com/jojo/ecommerce/application/dto/OrderPlaceEvent.java
+++ b/src/main/java/com/jojo/ecommerce/application/dto/OrderPlaceEvent.java
@@ -1,0 +1,17 @@
+package com.jojo.ecommerce.application.dto;
+
+import com.jojo.ecommerce.domain.model.OrderItem;
+
+import java.time.Instant;
+import java.util.List;
+
+public record OrderPlaceEvent(
+        Long orderId,
+        Long userId,
+        String requestId,
+        int totalQuantity,
+        int totalAmount,
+        List<OrderItem> items,
+        Instant occurredAt
+) {
+}

--- a/src/main/java/com/jojo/ecommerce/application/dto/PaymentCompleteEvent.java
+++ b/src/main/java/com/jojo/ecommerce/application/dto/PaymentCompleteEvent.java
@@ -1,0 +1,17 @@
+package com.jojo.ecommerce.application.dto;
+
+import com.jojo.ecommerce.domain.model.OrderItem;
+
+import java.time.Instant;
+import java.util.List;
+
+public record PaymentCompleteEvent(
+        Long orderId,
+        Long paymentId,
+        Long userId,
+        String requestId,
+        int paidAmount,
+        List<OrderItem> items,
+        Instant occurredAt
+) {
+}

--- a/src/main/java/com/jojo/ecommerce/application/port/out/DataPlatformPort.java
+++ b/src/main/java/com/jojo/ecommerce/application/port/out/DataPlatformPort.java
@@ -1,0 +1,7 @@
+package com.jojo.ecommerce.application.port.out;
+
+import java.util.Map;
+
+public interface DataPlatformPort {
+    void sendOrderEvent(Map<String, Object> payload, String idempotencyKey);
+}

--- a/src/main/java/com/jojo/ecommerce/application/service/DataPlatformClientRest.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/DataPlatformClientRest.java
@@ -16,11 +16,10 @@ import java.util.Map;
 @Primary
 @RequiredArgsConstructor
 public class DataPlatformClientRest implements DataPlatformPort {
-    private final RestTemplate  restTemplate;
+    private final RestTemplate restTemplate;
 
     @Value("${data-platform.base-url}")
     private String baseUrl;
-    private final DataPlatformClientRest dataPlatformClientRest;
 
     @Override
     public void sendOrderEvent(Map<String, Object> payload, String idempotencyKey) {
@@ -33,8 +32,6 @@ public class DataPlatformClientRest implements DataPlatformPort {
         if (idempotencyKey != null && !idempotencyKey.isBlank()) {
             headers.add("Idempotency-Key", idempotencyKey);
         }
-
-        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
-        restTemplate.postForEntity(baseUrl + path, entity, Void.class);
+        restTemplate.postForEntity(baseUrl + path, new HttpEntity<>(payload, headers), Void.class);
     }
 }

--- a/src/main/java/com/jojo/ecommerce/application/service/DataPlatformClientRest.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/DataPlatformClientRest.java
@@ -1,0 +1,40 @@
+package com.jojo.ecommerce.application.service;
+
+import com.jojo.ecommerce.application.port.out.DataPlatformPort;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+@Repository
+@Primary
+@RequiredArgsConstructor
+public class DataPlatformClientRest implements DataPlatformPort {
+    private final RestTemplate  restTemplate;
+
+    @Value("${data-platform.base-url}")
+    private String baseUrl;
+    private final DataPlatformClientRest dataPlatformClientRest;
+
+    @Override
+    public void sendOrderEvent(Map<String, Object> payload, String idempotencyKey) {
+        postJson("/events/order", payload, idempotencyKey);
+    }
+
+    private void postJson(String path, Map<String, Object> payload, String idempotencyKey) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        if (idempotencyKey != null && !idempotencyKey.isBlank()) {
+            headers.add("Idempotency-Key", idempotencyKey);
+        }
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(payload, headers);
+        restTemplate.postForEntity(baseUrl + path, entity, Void.class);
+    }
+}

--- a/src/main/java/com/jojo/ecommerce/application/service/DataPlatformEventListener.java
+++ b/src/main/java/com/jojo/ecommerce/application/service/DataPlatformEventListener.java
@@ -1,0 +1,44 @@
+package com.jojo.ecommerce.application.service;
+
+import com.jojo.ecommerce.application.dto.OrderPlaceEvent;
+import com.jojo.ecommerce.application.dto.PaymentCompleteEvent;
+import com.jojo.ecommerce.application.port.out.DataPlatformPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.HashMap;
+
+@Component
+@RequiredArgsConstructor
+public class DataPlatformEventListener {
+    private final DataPlatformPort dataPlatform;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onOrderPlaced(OrderPlaceEvent e) {
+        var payload = new HashMap<String, Object>();
+        payload.put("type", "ORDER_PLACED");
+        payload.put("orderId", e.orderId());
+        payload.put("userId", e.userId());
+        payload.put("totalQuantity", e.totalQuantity());
+        payload.put("totalAmount", e.totalAmount());
+        payload.put("occurredAt", e.occurredAt().toString());
+        dataPlatform.sendOrderEvent(payload, e.requestId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void onPaymentCompleted(PaymentCompleteEvent e) {
+        var payload = new HashMap<String, Object>();
+        payload.put("type", "PAYMENT_COMPLETED");
+        payload.put("orderId", e.orderId());
+        payload.put("paymentId", e.paymentId());
+        payload.put("userId", e.userId());
+        payload.put("paidAmount", e.paidAmount());
+        payload.put("occurredAt", e.occurredAt().toString());
+        dataPlatform.sendOrderEvent(payload, e.requestId());
+    }
+}

--- a/src/main/java/com/jojo/ecommerce/configuration/AsyncConfig.java
+++ b/src/main/java/com/jojo/ecommerce/configuration/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.jojo.ecommerce.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/jojo/ecommerce/configuration/RestTemplateConfig.java
+++ b/src/main/java/com/jojo/ecommerce/configuration/RestTemplateConfig.java
@@ -1,0 +1,22 @@
+package com.jojo.ecommerce.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(
+            RestTemplateBuilder builder,
+            @Value("${data-platform.connect-timeout-ms:1500}") int connectTimeoutMs,
+            @Value("${data-platform.read-timeout-ms:3000}") int readTimeoutMs
+    ) {
+        return builder.connectTimeout(Duration.ofMillis(connectTimeoutMs)).readTimeout(Duration.ofMillis(readTimeoutMs))
+                .build();
+    }
+}

--- a/src/main/java/com/jojo/ecommerce/configuration/RestTemplateConfig.java
+++ b/src/main/java/com/jojo/ecommerce/configuration/RestTemplateConfig.java
@@ -1,22 +1,21 @@
 package com.jojo.ecommerce.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
-
-import java.time.Duration;
 @Configuration
 public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate(
-            RestTemplateBuilder builder,
             @Value("${data-platform.connect-timeout-ms:1500}") int connectTimeoutMs,
             @Value("${data-platform.read-timeout-ms:3000}") int readTimeoutMs
     ) {
-        return builder.connectTimeout(Duration.ofMillis(connectTimeoutMs)).readTimeout(Duration.ofMillis(readTimeoutMs))
-                .build();
+        SimpleClientHttpRequestFactory f = new SimpleClientHttpRequestFactory();
+        f.setConnectTimeout(connectTimeoutMs);
+        f.setReadTimeout(readTimeoutMs);
+        return new RestTemplate(f);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,7 @@ mybatis.mapper-locations=classpath:mapper/**/*.xml
 mybatis.type-aliases-package=com.jojo.ecommerce.domain.model
 
 mybatis.configuration.map-underscore-to-camel-case=true
+
+data-platform.base-url=http://localhost:9090/mock-dp
+data-platform.connect-timeout-ms=1500
+data-platform.read-timeout-ms=3000

--- a/src/test/java/com/jojo/ecommerce/DataPlatformEventListenerIT.java
+++ b/src/test/java/com/jojo/ecommerce/DataPlatformEventListenerIT.java
@@ -1,0 +1,83 @@
+package com.jojo.ecommerce;
+
+import com.jojo.ecommerce.application.dto.PaymentCompleteEvent;
+import com.jojo.ecommerce.application.service.DataPlatformClientRest;
+import com.jojo.ecommerce.application.service.DataPlatformEventListener;
+import com.jojo.ecommerce.configuration.RestTemplateConfig;
+import com.jojo.ecommerce.domain.model.OrderItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.ApplicationEventMulticaster;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+@SpringBootTest(classes = {
+        RestTemplateConfig.class,
+        DataPlatformClientRest.class,
+        DataPlatformEventListener.class,
+        DataPlatformEventListenerIT.AsyncTestConfig.class
+})
+class DataPlatformEventListenerIT {
+
+    @Configuration
+    @EnableAsync
+    static class AsyncTestConfig {
+        @Bean(name = "applicationEventMulticaster")
+        public ApplicationEventMulticaster multicaster() {
+            var exec = new ThreadPoolTaskExecutor();
+            exec.setCorePoolSize(2);
+            exec.setMaxPoolSize(4);
+            exec.initialize();
+            var m = new org.springframework.context.event.SimpleApplicationEventMulticaster();
+            m.setTaskExecutor(exec);
+            return m;
+        }
+    }
+
+    @Autowired RestTemplate restTemplate;
+    @Autowired org.springframework.context.ApplicationEventPublisher publisher;
+
+    MockRestServiceServer server;
+
+    @BeforeEach
+    void setUp() {
+        server = MockRestServiceServer.bindTo(restTemplate).ignoreExpectOrder(true).build();
+        server.expect(requestTo("http://localhost:9090/mock-dp/events/order"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("Idempotency-Key", "REQ-xyz"))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"type\":\"PAYMENT_COMPLETED\"")))
+                .andRespond(withSuccess());
+    }
+
+    @Test
+    void 결제완료_이벤트가_트랜잭션없어도_실행된다_fallbackExecution() {
+        // 트랜잭션 없이 발행 → fallbackExecution=true 덕분에 즉시 실행
+        publisher.publishEvent(new PaymentCompleteEvent(
+                111L, 222L, 333L, "REQ-xyz", 9999,
+                List.of(new OrderItem(111L, 10L, 1, 1000)),
+                Instant.now()
+        ));
+
+        // @Async 비동기 완료까지 짧게 대기하며 검증
+        AssertionError last = null;
+        for (int i = 0; i < 30; i++) {
+            try { server.verify(); last = null; break; }
+            catch (AssertionError e) { last = e; try { Thread.sleep(100); } catch (InterruptedException ignored) {} }
+        }
+        if (last != null) throw last;
+    }
+}


### PR DESCRIPTION
## :pushpin: PR 제목 규칙
[STEP0X] 이름 - 선택 시나리오 (e-commerce/concert)

---
### STEP 15 Application Event
- [] 주문/예약 정보를 원 트랜잭션이 종료된 이후에 전송
- [] 주문/예약 정보를 전달하는 부가 로직에 대한 관심사를 메인 서비스에서 분리

### STEP 16 Transaction Diagnosis
- [] 도메인별로 트랜잭션이 분리되었을 때 발생 가능한 문제 파악
- [] 트랜잭션이 분리되더라도 데이터 일관성을 보장할 수 있는 분산 트랜잭션 설계

### **간단 회고** (3줄 이내)
- **잘한 점**:
- **어려운 점**:
- **다음 시도**:

#### 도메인 분리 시 트랜잭션 처리의 한계와 대응 방안 (요약)

#### 한계 (Problem)
- 글로벌 트랜잭션 부재: 서비스·DB 분리로 단일 ACID 트랜잭션 불가, 2PC/XA는 지연·가용성·운영 복잡도↑
- 이중 쓰기(Dual-write) 위험: DB 커밋과 이벤트/외부호출 분리 시 유실·중복·순서 역전으로 불일치 발생
- 글로벌 제약/조인 불가: 도메인 간 유니크 제약(멱등키)·조인을 DB 레벨에서 강제 불가
- 장시간/외부 의존: 결제/좌석 등 대기·실패를 로컬 트랜잭션으로 감싸기 어려움
- 부분 실패·중복·재시도: 네트워크/브로커 장애로 중복 소비·순서 뒤틀림·최종 일관성 지연 상시화
- 동시성·경합 증가: 재고/좌석 등 핫 리소스에서 경합·데드락 위험 상승

#### 대응 (Solution)
- Saga 패턴
  - Orchestration(권장, 복잡 플로우): 오케스트레이터가 단계·타임아웃·보상 통제
  - Choreography(부수 효과): 이벤트 구독으로 후행 작업(랭킹, 데이터 전송) 처리
- Outbox + 트랜잭셔널 메시징(필수): 도메인 변경과 이벤트 기록을 한 로컬 트랜잭션에 커밋 → Relay/CDC로 브로커 퍼블리시(dual-write 제거, at-least-once 전제)
- 멱등·중복·순서 제어: `requestId`/idempotency key 표준 + DB 유니크 인덱스, `processed_events`로 중복 소비 무시, 파티션 키(`orderId`/`concertId`)로 엔티티 단위 순서 보장
- 보상 트랜잭션: 실패 시 예약 해제·포인트 환급·쿠폰 복원·결제 취소 등 되돌리기 액션 표준화
- 경합 자원: TCC(Hold→Confirm→Cancel) + TTL 만료, DB 제약 + 짧은 임계구역 분산락(키 정렬로 데드락 회피)
- 조회 일관성: CQRS/Read Model로 교차 도메인 조인을 프로젝션으로 대체(결과적 일관성 수용, UI에 지연 허용 표시)
- 실패 대응 표준: 재시도(지수 백오프+Jitter)·타임아웃·서킷 브레이커, DLQ 격리, Outbox 적체/컨슈머 Lag/보상율·타임아웃율 모니터링, `traceId=requestId` 분산 추적

#### 최소 구현 체크리스트
- [ ] 각 서비스 DB에 Outbox 테이블 + 도메인 변경과 같은 트랜잭션으로 커밋
- [ ] Orchestrator 도입(주문→재고→결제→쿠폰/포인트) + 표준 보상 플로우
- [ ] Idempotency Key 유니크 인덱스 & processed_events 중복 처리
- [ ] 토픽 파티션 키 설계로 엔티티 단위 순서 보장
- [ ] CQRS 읽기 모델 정의(핵심 조회)
- [ ] 재시도/백오프/타임아웃/DLQ/모니터링/분산 추적 기본 세트 적용

#### 결론
- 글로벌 트랜잭션을 강제하지 말고, Saga + Outbox + 멱등/보상 + CQRS로 결과적 일관성을 체계적으로 달성한다.
